### PR TITLE
fix: nil pointer dereference in checkBadReferrer method

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -421,7 +421,6 @@ func (t *Teler) checkBadReferrer(r *http.Request) error {
 
 	// Check if the referrer request is in cache
 	if err, ok := t.getCache(eTLD1); ok {
-		t.error(zapcore.ErrorLevel, err.Error())
 		return err
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a PR without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

<!-- Please provide enough information so that others can review your pull request. -->
<!-- For more information, see the CONTRIBUTING.md guide. -->

This commit fixes a bug in the `checkBadReferrer` method where a nil pointer dereference occurred. The code was checking if an error occurred and returning it without handling the case when the error is nil. This caused a panic at runtime when trying to access a nil pointer. The fix removes the error logging statement and returns early when the error is nil, preventing the panic from happening.


### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- Bug #60 

<!-- What existing problem does the pull request solve? -->

### How has this been tested?

Proof:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output or/ screenshots. -->

### Closing issues

Fixes #60

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My changes successfully ran and pass linters locally (run `make lint`).
- [ ] I have written new tests for my changes.
  - [ ] My changes successfully ran and pass tests locally.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.