### PR TITLE
refactor: move `getResources()` method call down

### DIFF
--- a/teler.go
+++ b/teler.go
@@ -158,12 +158,6 @@ func New(opts ...Options) *Teler {
 		_ = t.log.Sync()
 	}()
 
-	// Retrieve the data for each threat category
-	err = t.getResources()
-	if err != nil {
-		t.error(zapcore.PanicLevel, fmt.Sprintf(errResources, err))
-	}
-
 	// Initialize the excludes field of the Threat struct to a new map and
 	// set the boolean flag for each threat category specified in the Excludes option to true
 	t.threat.excludes = map[threat.Threat]bool{
@@ -314,6 +308,12 @@ func New(opts ...Options) *Teler {
 
 	// Set the opt field of the Teler struct to the options
 	t.opt = o
+
+	// Retrieve the data for each threat category
+	err = t.getResources()
+	if err != nil {
+		t.error(zapcore.PanicLevel, fmt.Sprintf(errResources, err))
+	}
 
 	return t
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a PR without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

<!-- Please provide enough information so that others can review your pull request. -->
<!-- For more information, see the CONTRIBUTING.md guide. -->

The commit moves the `(*Teler).getResources()` method call down in the `New()` function. This was done because the previous placement of the call caused an unexpected behavior (`InMemory` is always false), and moving it to a later stage in the function resolves the issue.

### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- Bug 1
- Bug 2
- Feature 1
- Feature 2
- Breaking changes

<!-- What existing problem does the pull request solve? -->

### How has this been tested?

Proof:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output or/ screenshots. -->

### Closing issues

Fixes #

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My changes successfully ran and pass linters locally (run `make lint`).
- [x] I have written new tests for my changes.
  - [x] My changes successfully ran and pass tests locally.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.