### PR TITLE
refactor: use single regexp engine

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -7,14 +7,12 @@ package teler
 
 import (
 	"errors"
-	"regexp"
 	"strings"
 
 	"net/http"
 
 	"github.com/kitabisa/teler-waf/request"
 	"github.com/kitabisa/teler-waf/threat"
-	"github.com/scorpionknifes/go-pcre"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/publicsuffix"
 )
@@ -234,21 +232,11 @@ func (t *Teler) checkCommonWebAttack(r *http.Request) error {
 
 	// Iterate over the filters in the CommonWebAttack data stored in the t.threat.cwa.Filters field
 	for _, filter := range t.threat.cwa.Filters {
-		// Initialize a variable to track whether a match is found
-		var match bool
+		// Check if the pattern matches the request URI or request body
+		match := filter.pattern.MatchString(uri, 0) || filter.pattern.MatchString(body, 0)
 
-		// Check the type of the filter's pattern
-		switch pattern := filter.pattern.(type) {
-		case *regexp.Regexp: // If the pattern is a regex
-			match = pattern.MatchString(uri) || pattern.MatchString(body)
-		case *pcre.Matcher: // If the pattern is a PCRE expr
-			match = pattern.MatchString(uri, 0) || pattern.MatchString(body, 0)
-		default: // If the pattern is of an unknown type, skip to the next iteration
-			continue
-		}
-
-		// If the pattern matches the request URI or body, cache the request
-		// and return an error indicating a common web attack has been detected
+		// If matched, set cache for the request and return an
+		// error indicating a common web attack has been detected
 		if match {
 			t.setCache(key, filter.Description)
 			return errors.New(filter.Description)

--- a/analyze.go
+++ b/analyze.go
@@ -503,22 +503,9 @@ func (t *Teler) checkBadCrawler(r *http.Request) error {
 
 	// Iterate over BadCrawler compiled patterns and do the check
 	for _, pattern := range t.threat.badCrawler {
-		// Initialize a variable to track whether a match is found
-		var match bool
-
-		// Check the type of the pattern
-		switch p := pattern.(type) {
-		case *regexp.Regexp: // If the pattern is a regex
-			match = p.MatchString(ua)
-		case *pcre.Matcher: // If the pattern is a PCRE expr
-			match = p.MatchString(ua, 0)
-		default: // If the pattern is of an unknown type, skip to the next iteration
-			continue
-		}
-
 		// Check if the pattern is not nil and matches the User-Agent,
-		// cache the User-Agent if it matched
-		if match {
+		// then cache the User-Agent if it matched
+		if pattern.MatchString(ua, 0) {
 			t.setCache(ua, errBadCrawler)
 			return errors.New(errBadCrawler)
 		}

--- a/cwa.go
+++ b/cwa.go
@@ -5,6 +5,8 @@
 
 package teler
 
+import "github.com/scorpionknifes/go-pcre"
+
 type cwa struct {
 	Filters []struct {
 		Description string   `json:"description"`
@@ -12,6 +14,6 @@ type cwa struct {
 		Impact      int64    `json:"impact"`
 		Rule        string   `json:"rule"`
 		Tags        []string `json:"tags"`
-		pattern     interface{}
+		pattern     *pcre.Matcher
 	} `json:"filters"`
 }

--- a/teler.go
+++ b/teler.go
@@ -566,18 +566,13 @@ func (t *Teler) processResource(k threat.Threat) error {
 
 		// Compile the regular expression patterns from the filter rules
 		for i, filter := range t.threat.cwa.Filters {
-			// Compile the filter rule as a regular expression
-			t.threat.cwa.Filters[i].pattern, err = regexp.Compile(filter.Rule) // nosemgrep: trailofbits.go.questionable-assignment.questionable-assignment
+			// Compile the filter rule as a perl-compatible regular expression
+			cpcre, err := pcre.Compile(filter.Rule, pcre.MULTILINE)
 			if err != nil {
-				// If the regular expression cannot be compiled,
-				// try to compile it as a PCRE pattern
-				cpcre, err := pcre.Compile(filter.Rule, pcre.MULTILINE)
-				if err == nil {
-					// If the PCRE pattern is successfully compiled,
-					// create a new Matcher and assign it to the pattern field
-					t.threat.cwa.Filters[i].pattern = cpcre.NewMatcher()
-				}
+				return err
 			}
+
+			t.threat.cwa.Filters[i].pattern = cpcre.NewMatcher()
 		}
 	case threat.CVE:
 		// Initialize the cve field of the threat struct.

--- a/teler.go
+++ b/teler.go
@@ -63,9 +63,9 @@ type Threat struct {
 	// strings containing the data for the corresponding threat category.
 	data map[threat.Threat]string
 
-	// badCrawler contains the compiled slices of pointers to regexp.Regexp
-	// and pcre.Matcher objects of BadCrawler threat data as interface.
-	badCrawler []interface{}
+	// badCrawler contains the compiled slices of pcre.Matcher pointers
+	// objects of BadCrawler threat data.
+	badCrawler []*pcre.Matcher
 
 	// cve contains the compiled JSON CVEs data of pointers to fastjson.Value
 	cve *fastjson.Value
@@ -647,20 +647,15 @@ func (t *Teler) processResource(k threat.Threat) error {
 		// Split the data into a slice of strings, compile each string
 		// into a regex or pcre expr, and save it in the badCrawler field.
 		patterns := strings.Split(t.threat.data[k], "\n")
-		t.threat.badCrawler = make([]interface{}, len(patterns))
+		t.threat.badCrawler = make([]*pcre.Matcher, len(patterns))
 
 		for i, pattern := range patterns {
-			t.threat.badCrawler[i], err = regexp.Compile(pattern)
+			cpcre, err := pcre.Compile(pattern, pcre.MULTILINE)
 			if err != nil {
-				// If the regular expression cannot be compiled,
-				// try to compile it as a PCRE pattern
-				cpcre, err := pcre.Compile(pattern, pcre.MULTILINE)
-				if err == nil {
-					// If the PCRE pattern is successfully compiled,
-					// create a new Matcher and assign it to the pattern field
-					t.threat.badCrawler[i] = cpcre.NewMatcher()
-				}
+				return err
 			}
+
+			t.threat.badCrawler[i] = cpcre.NewMatcher()
 		}
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a PR without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

Use a single regexp engine to check `BadReferrer` or `CommonWebAttack`.

### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- Close #83 

<!-- What existing problem does the pull request solve? -->

### How has this been tested?

Proof:

```console
$ make bench-initialize 
go test -bench "^BenchmarkInitialize" -cpu=4 
goos: linux
goarch: amd64
pkg: github.com/kitabisa/teler-waf
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkInitializeDefault-4                      	      67	  17868927 ns/op	40534760 B/op	   86866 allocs/op
BenchmarkInitializeCommonWebAttack-4              	      62	  17913282 ns/op	40534564 B/op	   86866 allocs/op
BenchmarkInitializeCVE-4                          	      66	  18180315 ns/op	40534110 B/op	   86864 allocs/op
BenchmarkInitializeBadIPAddress-4                 	      54	  19742513 ns/op	40534697 B/op	   86866 allocs/op
BenchmarkInitializeBadReferrer-4                  	      56	  19663486 ns/op	40534316 B/op	   86865 allocs/op
BenchmarkInitializeBadCrawler-4                   	      64	  18505315 ns/op	40534615 B/op	   86866 allocs/op
BenchmarkInitializeDirectoryBruteforce-4          	      58	  17361725 ns/op	40534423 B/op	   86865 allocs/op
BenchmarkInitializeWithoutCommonWebAttack-4       	      64	  18531537 ns/op	40534350 B/op	   86865 allocs/op
BenchmarkInitializeWithoutCVE-4                   	      60	  18429654 ns/op	40534103 B/op	   86864 allocs/op
BenchmarkInitializeWithoutBadIPAddress-4          	      57	  18648138 ns/op	40534111 B/op	   86865 allocs/op
BenchmarkInitializeWithoutBadReferrer-4           	      61	  19783743 ns/op	40534224 B/op	   86865 allocs/op
BenchmarkInitializeWithoutBadCrawler-4            	      66	  18635323 ns/op	40534011 B/op	   86864 allocs/op
BenchmarkInitializeWithoutDirectoryBruteforce-4   	      61	  19607539 ns/op	40534159 B/op	   86865 allocs/op
BenchmarkInitializeCustomRules-4                  	      50	  20585198 ns/op	40537215 B/op	   86897 allocs/op
PASS
ok  	github.com/kitabisa/teler-waf	30.913s
```

### Closing issues

Fixes #83

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My changes successfully ran and pass linters locally (run `make lint`).
- [x] I have written new tests for my changes.
  - [x] My changes successfully ran and pass tests locally.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.