### PR TITLE
refactor: use pcre regexp engine for custom rule

### DIFF
--- a/analyze.go
+++ b/analyze.go
@@ -166,13 +166,13 @@ func (t *Teler) checkCustomRules(r *http.Request) error {
 			// If it matches, set ok to true
 			switch cond.Element {
 			case request.URI:
-				ok = pattern.MatchString(uri)
+				ok = pattern.MatchString(uri, 0)
 			case request.Headers:
-				ok = pattern.MatchString(headers)
+				ok = pattern.MatchString(headers, 0)
 			case request.Body:
-				ok = pattern.MatchString(body)
+				ok = pattern.MatchString(body, 0)
 			case request.Any:
-				ok = (pattern.MatchString(uri) || pattern.MatchString(headers) || pattern.MatchString(body))
+				ok = (pattern.MatchString(uri, 0) || pattern.MatchString(headers, 0) || pattern.MatchString(body, 0))
 			}
 
 			// If the rule condition is satisfied, increment the found match counter

--- a/condition.go
+++ b/condition.go
@@ -6,10 +6,9 @@
 package teler
 
 import (
-	"regexp"
-
 	"github.com/antonmedv/expr/vm"
 	"github.com/kitabisa/teler-waf/request"
+	"github.com/scorpionknifes/go-pcre"
 )
 
 // Condition specifies a request element to match and
@@ -41,7 +40,7 @@ type Condition struct {
 
 	// patternRegex saves the compiled regular expressions of the
 	// Pattern for subsequent use.
-	patternRegex *regexp.Regexp
+	patternRegex *pcre.Matcher
 
 	// DSL is the DSL expression to match against the incoming requests.
 	DSL string `json:"dsl" yaml:"dsl"`

--- a/teler.go
+++ b/teler.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -271,13 +270,13 @@ func New(opts ...Options) *Teler {
 				t.error(zapcore.PanicLevel, fmt.Sprintf(errPattern, rule.Name, "pattern cannot be empty"))
 			}
 
-			// Compile the regular expression pattern
-			regex, err := regexp.Compile(cond.Pattern)
+			// Compile the condition pattern
+			cpcre, err := pcre.Compile(cond.Pattern, pcre.MULTILINE)
 			if err != nil {
 				t.error(zapcore.PanicLevel, fmt.Sprintf(errPattern, rule.Name, err.Error()))
 			}
 
-			rule.Rules[i].patternRegex = regex
+			rule.Rules[i].patternRegex = cpcre.NewMatcher()
 		}
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a PR without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

<!-- Please provide enough information so that others can review your pull request. -->
<!-- For more information, see the CONTRIBUTING.md guide. -->

Supporting PCRE pattern for custom rule condition.


### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- Feature #83 

<!-- What existing problem does the pull request solve? -->

### How has this been tested?

Proof:

### Before

```console
$ go test -run "^$" -bench "^BenchmarkInitializeCustomRule" -cpu=4 -count 10 | tee /tmp/old.txt 
goos: linux
goarch: amd64
pkg: github.com/kitabisa/teler-waf
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkInitializeCustomRules-4   	       1	2137316062 ns/op	51628184 B/op	  137066 allocs/op
BenchmarkInitializeCustomRules-4   	      64	  16842722 ns/op	40538818 B/op	   86929 allocs/op
BenchmarkInitializeCustomRules-4   	      58	  19287922 ns/op	40538565 B/op	   86927 allocs/op
BenchmarkInitializeCustomRules-4   	      61	  18448952 ns/op	40539070 B/op	   86928 allocs/op
BenchmarkInitializeCustomRules-4   	      61	  20377034 ns/op	40539019 B/op	   86929 allocs/op
BenchmarkInitializeCustomRules-4   	      62	  17853707 ns/op	40538648 B/op	   86927 allocs/op
BenchmarkInitializeCustomRules-4   	      66	  18291841 ns/op	40538705 B/op	   86928 allocs/op
BenchmarkInitializeCustomRules-4   	      55	  18771989 ns/op	40538675 B/op	   86928 allocs/op
BenchmarkInitializeCustomRules-4   	      54	  19569256 ns/op	40538421 B/op	   86926 allocs/op
BenchmarkInitializeCustomRules-4   	      57	  18205604 ns/op	40538455 B/op	   86926 allocs/op
PASS
ok  	github.com/kitabisa/teler-waf	14.273s
```

### After

```console
$ go test -run "^$" -bench "^BenchmarkInitializeCustomRule" -cpu=4 -count 10 | tee /tmp/new.txt 
goos: linux
goarch: amd64
pkg: github.com/kitabisa/teler-waf
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkInitializeCustomRules-4   	       1	1843819726 ns/op	51602368 B/op	  137023 allocs/op
BenchmarkInitializeCustomRules-4   	      61	  19268530 ns/op	40536153 B/op	   86902 allocs/op
BenchmarkInitializeCustomRules-4   	      52	  19921854 ns/op	40535659 B/op	   86901 allocs/op
BenchmarkInitializeCustomRules-4   	      62	  17659282 ns/op	40535529 B/op	   86900 allocs/op
BenchmarkInitializeCustomRules-4   	      56	  18588371 ns/op	40535385 B/op	   86900 allocs/op
BenchmarkInitializeCustomRules-4   	      52	  19926338 ns/op	40535689 B/op	   86901 allocs/op
BenchmarkInitializeCustomRules-4   	      69	  19771510 ns/op	40535983 B/op	   86902 allocs/op
BenchmarkInitializeCustomRules-4   	      52	  20148745 ns/op	40535630 B/op	   86901 allocs/op
BenchmarkInitializeCustomRules-4   	      66	  18331248 ns/op	40535946 B/op	   86902 allocs/op
BenchmarkInitializeCustomRules-4   	      58	  17675152 ns/op	40536178 B/op	   86902 allocs/op
PASS
ok  	github.com/kitabisa/teler-waf	13.790s
```

### Conclusion

```console
$ benchstat old.txt new.txt 
goos: linux
goarch: amd64
pkg: github.com/kitabisa/teler-waf
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
                        │   old.txt   │            new.txt            │
                        │   sec/op    │   sec/op     vs base          │
InitializeCustomRules-4   18.61m ± 9%   19.52m ± 9%  ~ (p=0.579 n=10)

                        │   old.txt    │               new.txt               │
                        │     B/op     │     B/op      vs base               │
InitializeCustomRules-4   38.66Mi ± 0%   38.66Mi ± 0%  -0.01% (p=0.001 n=10)

                        │   old.txt   │              new.txt               │
                        │  allocs/op  │  allocs/op   vs base               │
InitializeCustomRules-4   86.93k ± 0%   86.90k ± 0%  -0.03% (p=0.001 n=10)
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output or/ screenshots. -->

### Closing issues

Fixes #83 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My changes successfully ran and pass linters locally (run `make lint`).
- [x] I have written new tests for my changes.
  - [x] My changes successfully ran and pass tests locally.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.