### PR TITLE
fix: nil pointer deref `sendFalcoEvents` func

### DIFF
--- a/falcosidekick.go
+++ b/falcosidekick.go
@@ -109,8 +109,9 @@ func (t *Teler) sendFalcoEvents() {
 			if err != nil {
 				// Handle HTTP POST request error by logging an error message.
 				t.error(zapcore.ErrorLevel, err.Error())
+			} else {
+				defer resp.Body.Close()
 			}
-			defer resp.Body.Close()
 		})
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a PR without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

<!-- Please provide enough information so that others can review your pull request. -->
<!-- For more information, see the CONTRIBUTING.md guide. -->

The previous code in the `sendFalcoEvents()` function attempted to defer the closing of the response body w/o checking if the HTTP request had resulted in an error. This could lead to a "nil pointer dereference" error when an error occurred during the request.

This commit fixes the issue by checking if an error occurred and deferring the response body close only if there was no error.


### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- Bug 1
- Bug 2
- Feature 1
- Feature 2
- Breaking changes

<!-- What existing problem does the pull request solve? -->

### How has this been tested?

Fill the `FalcoSidekickURL` option field with an unreachable host.

Proof:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output or/ screenshots. -->

### Closing issues

Fixes #

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My changes successfully ran and pass linters locally (run `make lint`).
- [x] I have written new tests for my changes.
  - [x] My changes successfully ran and pass tests locally.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.