### PR TITLE
fix: data race on count pending Falco events

### DIFF
--- a/falcosidekick.go
+++ b/falcosidekick.go
@@ -61,12 +61,18 @@ func (t *Teler) checkFalcoEvents() {
 
 	// Check for pending Falco events every 5 seconds.
 	for range ticker.C {
+		// Lock the FalcoSidekick event
+		t.falcoSidekick.sl.Lock()
+
 		// Get the count of pending Falco events.
 		c := len(t.falcoSidekick.events)
 		if c > 0 {
 			// Send pending Falco events to FalcoSidekick.
 			t.sendFalcoEvents()
 		}
+
+		// Unlock the FalcoSidekick event
+		t.falcoSidekick.sl.Unlock()
 	}
 }
 

--- a/teler_test.go
+++ b/teler_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"net/http"
 	"net/http/httptest"
@@ -286,6 +287,8 @@ func TestNewWithFalcoSidekickURL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	time.Sleep(5 * time.Second)
 }
 
 func TestNewWithVerbose(t *testing.T) {


### PR DESCRIPTION
**IMPORTANT: Please do not create a PR without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

<!-- Please provide enough information so that others can review your pull request. -->
<!-- For more information, see the CONTRIBUTING.md guide. -->

Race condition while count pending Falco events in `checkFalcoEvents`.

### Proposed of changes

This PR fixes/implements the following **bugs/features**:

- #111 

<!-- What existing problem does the pull request solve? -->

### How has this been tested?

Proof:

```console
$ go test -v -cover -race -count=1 -run="TestNewWithFalcoSidekickURL" ./
=== RUN   TestNewWithFalcoSidekickURL
--- PASS: TestNewWithFalcoSidekickURL (8.19s)
PASS
coverage: 48.2% of statements
ok  	github.com/kitabisa/teler-waf	9.243s	coverage: 48.2% of statements
```

### Closing issues

Fixe #111

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My changes successfully ran and pass linters locally (run `make lint`).
- [x] I have written new tests for my changes.
  - [x] My changes successfully ran and pass tests locally.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.