### PR TITLE
refactor: update pkg caller identification in initialize

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	golang.org/x/net v0.19.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
+	tlog.app/go/loc v0.6.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1000,3 +1000,5 @@ mvdan.cc/sh/v3 v3.6.0/go.mod h1:U4mhtBLZ32iWhif5/lD+ygy1zrgaQhUu+XFy7C8+TTA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+tlog.app/go/loc v0.6.1 h1:Eae0owcUBxpQm5KRuZHJFQKXlA7D8hGMw53tKdp0zMY=
+tlog.app/go/loc v0.6.1/go.mod h1:k5eWl4QTHUxt1iyV324nJ/I6ib9KgjlluOl1A634IyE=

--- a/teler.go
+++ b/teler.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
@@ -46,6 +45,7 @@ import (
 	"github.com/valyala/fastjson"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"tlog.app/go/loc"
 )
 
 // Threat defines what threat category should be excluded
@@ -126,8 +126,8 @@ func New(opts ...Options) *Teler {
 	}
 
 	// Get the package name of the calling package
-	_, file, _, ok := runtime.Caller(1)
-	if ok {
+	if pc := loc.Caller(1); pc != 0 {
+		_, file, _ := pc.NameFileLine()
 		t.caller = path.Base(path.Dir(file))
 	}
 


### PR DESCRIPTION
**IMPORTANT: Please do not create a PR without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

Performance improvements.

### Proposed of changes

Replace the usage of `runtime.Caller` with the faster, zero memory allocation, and convenient `loc.Caller` in `teler.New`.

This change introduces a performance improvement, especially when using the `nikandfor_loc_unsafe` build tag.

<!-- What existing problem does the pull request solve? -->

### How has this been tested?

Proof:

```console
$ benchstat c6ab7f3.txt ee9d80d.txt
goos: linux
goarch: amd64
pkg: github.com/kitabisa/teler-waf
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
                    │ c6ab7f3.txt │          ee9d80d.txt          │
                    │   sec/op    │   sec/op     vs base          │
InitializeDefault-4   21.51m ± 2%   21.29m ± 3%  ~ (p=0.893 n=25)

                    │ c6ab7f3.txt  │          ee9d80d.txt           │
                    │     B/op     │     B/op      vs base          │
InitializeDefault-4   41.04Mi ± 0%   41.04Mi ± 0%  ~ (p=0.164 n=25)

                    │ c6ab7f3.txt │            ee9d80d.txt             │
                    │  allocs/op  │  allocs/op   vs base               │
InitializeDefault-4   97.18k ± 0%   97.18k ± 0%  -0.00% (p=0.000 n=25)
```

<details>
<summary>Click to toggle contents of <code>c6ab7f3.txt</code></summary>

```
goos: linux
goarch: amd64
pkg: github.com/kitabisa/teler-waf
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkInitializeDefault-4   	       1	6943774640 ns/op	53499856 B/op	  147380 allocs/op
BenchmarkInitializeDefault-4   	      56	  19728628 ns/op	43029612 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      56	  21114282 ns/op	43029593 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      52	  21387548 ns/op	43029730 B/op	   97181 allocs/op
BenchmarkInitializeDefault-4   	      56	  21154683 ns/op	43029283 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      55	  22137696 ns/op	43029237 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      58	  20377697 ns/op	43029031 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      54	  20161663 ns/op	43029574 B/op	   97181 allocs/op
BenchmarkInitializeDefault-4   	      58	  21412840 ns/op	43029622 B/op	   97181 allocs/op
BenchmarkInitializeDefault-4   	      50	  21929395 ns/op	43029405 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      57	  22482575 ns/op	43029316 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      54	  22783577 ns/op	43028698 B/op	   97178 allocs/op
BenchmarkInitializeDefault-4   	      54	  21640284 ns/op	43029469 B/op	   97181 allocs/op
BenchmarkInitializeDefault-4   	      54	  21789341 ns/op	43029488 B/op	   97181 allocs/op
BenchmarkInitializeDefault-4   	      54	  21618026 ns/op	43029118 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      55	  23402962 ns/op	43028896 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      57	  22919705 ns/op	43029119 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      54	  20159687 ns/op	43028692 B/op	   97178 allocs/op
BenchmarkInitializeDefault-4   	      55	  21332403 ns/op	43029139 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      56	  20665475 ns/op	43028856 B/op	   97178 allocs/op
BenchmarkInitializeDefault-4   	      57	  19852269 ns/op	43029307 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      49	  22173652 ns/op	43029489 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      60	  21521963 ns/op	43029027 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      49	  21513272 ns/op	43029449 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      55	  19290917 ns/op	43029307 B/op	   97180 allocs/op
PASS
ok  	github.com/kitabisa/teler-waf	43.214s

```
</details>

<details>
<summary>Click to toggle contents of <code>ee9d80d.txt</code></summary>

```
goos: linux
goarch: amd64
pkg: github.com/kitabisa/teler-waf
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkInitializeDefault-4   	       1	6158751633 ns/op	53568392 B/op	  147365 allocs/op
BenchmarkInitializeDefault-4   	      63	  21616492 ns/op	43029563 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      57	  18810485 ns/op	43028810 B/op	   97176 allocs/op
BenchmarkInitializeDefault-4   	      54	  21556582 ns/op	43029062 B/op	   97178 allocs/op
BenchmarkInitializeDefault-4   	      55	  20606970 ns/op	43028879 B/op	   97177 allocs/op
BenchmarkInitializeDefault-4   	      55	  21939790 ns/op	43028895 B/op	   97177 allocs/op
BenchmarkInitializeDefault-4   	      60	  20854406 ns/op	43028868 B/op	   97177 allocs/op
BenchmarkInitializeDefault-4   	      54	  20682572 ns/op	43029089 B/op	   97178 allocs/op
BenchmarkInitializeDefault-4   	      48	  21281135 ns/op	43029642 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      56	  19842726 ns/op	43029199 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      57	  22552012 ns/op	43029700 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      61	  22625870 ns/op	43029148 B/op	   97177 allocs/op
BenchmarkInitializeDefault-4   	      50	  23054691 ns/op	43029423 B/op	   97180 allocs/op
BenchmarkInitializeDefault-4   	      48	  22867070 ns/op	43029154 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      55	  21902671 ns/op	43029307 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      60	  21302888 ns/op	43028864 B/op	   97177 allocs/op
BenchmarkInitializeDefault-4   	      50	  21288711 ns/op	43028820 B/op	   97177 allocs/op
BenchmarkInitializeDefault-4   	      44	  23495557 ns/op	43029207 B/op	   97178 allocs/op
BenchmarkInitializeDefault-4   	      56	  20917763 ns/op	43029292 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      58	  21242986 ns/op	43029038 B/op	   97178 allocs/op
BenchmarkInitializeDefault-4   	      56	  22283995 ns/op	43029239 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      52	  19579127 ns/op	43028545 B/op	   97176 allocs/op
BenchmarkInitializeDefault-4   	      51	  20948054 ns/op	43029351 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      54	  21088987 ns/op	43029360 B/op	   97179 allocs/op
BenchmarkInitializeDefault-4   	      57	  20678469 ns/op	43029012 B/op	   97178 allocs/op
PASS
ok  	github.com/kitabisa/teler-waf	39.512s

```
</details>

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output or/ screenshots. -->

### Closing issues

Fixes #

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My changes successfully ran and pass linters locally (run `make lint`).
- [ ] I have written new tests for my changes.
  - [ ] My changes successfully ran and pass tests locally.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.